### PR TITLE
Added missing use for Tags/Model/TagsQuery in Tags.php

### DIFF
--- a/Tags.php
+++ b/Tags.php
@@ -13,6 +13,7 @@
 namespace Tags;
 
 use Propel\Runtime\Connection\ConnectionInterface;
+use Tags\Model\TagsQuery;
 use Thelia\Install\Database;
 use Thelia\Module\BaseModule;
 


### PR DESCRIPTION
Module cannot properly activates without it because TagsQuery is used in method postActivation.